### PR TITLE
Version 5.3.1 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=Laser Utils
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU GPL 3.0
 # The mod version. See https://semver.org/
-mod_version=5.2.1
+mod_version=5.3.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/laserdiamond/laserutils/client/overlay/LUOverlayManager.java
+++ b/src/main/java/net/laserdiamond/laserutils/client/overlay/LUOverlayManager.java
@@ -2,7 +2,6 @@ package net.laserdiamond.laserutils.client.overlay;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.LayeredDraw;
-import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 import java.util.HashMap;
@@ -15,27 +14,20 @@ import java.util.function.BooleanSupplier;
  */
 public class LUOverlayManager {
 
-    /**
-     * Creates a new {@linkplain LUOverlayManager HUD Overlay Manager}. This should be called in your mod's constructor
-     * @param eventBus Your mod's {@linkplain IEventBus mod event bus}
-     */
-    public static LUOverlayManager createOverlayManager(IEventBus eventBus)
-    {
-        return new LUOverlayManager(eventBus);
-    }
-
     private final HashMap<LayeredDraw, BooleanSupplier> conditionalOverlays;
     private final HashMap<LayeredDraw, BooleanSupplier> firstConditionalOverlays;
     private final Set<LayeredDraw.Layer> overlays;
     private final Set<LayeredDraw.Layer> firstOverlays;
 
-    private LUOverlayManager(IEventBus eventBus)
+    /**
+     * Creates a new {@linkplain LUOverlayManager HUD Overlay Manager}
+     */
+    public LUOverlayManager()
     {
         this.conditionalOverlays = new HashMap<>();
         this.overlays = new HashSet<>();
         this.firstConditionalOverlays = new HashMap<>();
         this.firstOverlays = new HashSet<>();
-        eventBus.addListener(this::clientSetUp);
     }
 
     /**
@@ -88,7 +80,7 @@ public class LUOverlayManager {
      * Registers the layer when the {@linkplain FMLClientSetupEvent FML Client Set Up} is called
      * @param event The {@linkplain FMLClientSetupEvent FML Client Set Up Event} to listen for
      */
-    private void clientSetUp(FMLClientSetupEvent event)
+    public void clientSetUp(FMLClientSetupEvent event)
     {
         Minecraft minecraft = Minecraft.getInstance();
         LayeredDraw mcLayers = minecraft.gui.layers;


### PR DESCRIPTION
### **Version 5.3.1**

- Fixed LUOverlayManager causing crashes when adding overlays
  - LUOverlayManager no longer requires IEventBus as a parameter
  - LUOverlayManager#clientSetUp can be called during an FMLClientSetupEvent to register the layers